### PR TITLE
[hot-fix] Fix use of Object.assign in configure-tasks.spec.js

### DIFF
--- a/test/tasks/pop/configure-tasks.spec.js
+++ b/test/tasks/pop/configure-tasks.spec.js
@@ -1,4 +1,5 @@
 import * as lib from "../../../src/tasks/pop/configure-tasks";
+import assign from "../../../src/util/assign";
 import neighbours from "../../fixtures/neighbours";
 
 const fixture = {
@@ -46,7 +47,7 @@ describe("Configure POP tasks", () => {
       const othersFixture = ["HHN", "MAD"];
       const allFixture = neighboursFixture.concat(othersFixture);
       const result = lib.transform(
-        Object.assign({}, fixture, { pops: allFixture }),
+        assign({}, fixture, { pops: allFixture }),
         5,
         0
       );


### PR DESCRIPTION
### TL;DR
Fix use of `Object.assign` in configure-tasks test.

### Why
This was breaking an upstream cross-browser test in Chrome 42 as some of our supported browsers don't support the api, hence the liberal use of the ponyfil through the project.

This is blocking all new deployments of the library in production. 