### PR TITLE
Use new shorter url paths for all requests

### DIFF
--- a/src/tasks/pop/index.js
+++ b/src/tasks/pop/index.js
@@ -7,9 +7,7 @@ import { asyncGetEntry, normalizeEntry } from "../../lib/resource-timing";
 class Pop extends Task {
   constructor(config) {
     super(config);
-    this.url = `https://${this.config.host}/test_object.svg?unique=${
-      this.config.testId
-    }`;
+    this.url = `https://${this.config.host}/o.svg?u=${this.config.testId}`;
     this.url = this.url.toLowerCase();
   }
 

--- a/src/tasks/task.js
+++ b/src/tasks/task.js
@@ -50,7 +50,7 @@ class Task {
     return Promise.all([
       this.run(),
       getClientInfo(
-        `https://${this.config.testId}.${this.config.hosts.lookup}/lookup`
+        `https://${this.config.testId}.${this.config.hosts.lookup}/l`
       )
     ])
       .then(result => this.generateResult(this.config, ...result))

--- a/src/tasks/task.js
+++ b/src/tasks/task.js
@@ -25,7 +25,7 @@ class Task {
 
   send(data) {
     const { apiKey, session, hosts: { host } } = this.config;
-    const url = `https://${host}/beacon?k=${apiKey}&s=${session}`;
+    const url = `https://${host}/b?k=${apiKey}&s=${session}`;
     beacon(url, data);
   }
 

--- a/test/tasks/task.spec.js
+++ b/test/tasks/task.spec.js
@@ -103,7 +103,7 @@ describe("Task", () => {
 
     it("should construct a query string with credentials", () => {
       task.send(dataFixture);
-      const url = `https://${fixture.hosts.host}/beacon?k=${fixture.apiKey}&s=${
+      const url = `https://${fixture.hosts.host}/b?k=${fixture.apiKey}&s=${
         fixture.session
       }`;
       expect(spy).to.have.been.called.with(url);


### PR DESCRIPTION
Cleans up the URL paths throughout the application to use the new shorter version of each request type: `beacon`, `lookup` and `test_object`. Simply to save bytes and have a cleaner external interface. 