### PR TITLE
Fix the cuts-the-mustard test in scout.js

### DIFF
--- a/src/scout.js
+++ b/src/scout.js
@@ -1,10 +1,11 @@
 /* global config, FASTLY */
 import hasProp from "./util/has";
 
-const cutsTheMustard = (config.ctm = (hasProp(window, "Promise"),
-hasProp(window, "Set"),
-hasProp(window, "fetch"),
-hasProp(window, "performance.getEntries")));
+const cutsTheMustard = (config.ctm =
+  hasProp(window, "Promise") &&
+  hasProp(window, "Set") &&
+  hasProp(window, "fetch") &&
+  hasProp(window, "performance.getEntries"));
 
 function isWithinSample(sample) {
   const seed = parseFloat(Math.random().toFixed(2));


### PR DESCRIPTION
This fixes the `cutsTheMustard` feature detection test within the initialisation of the scout.js file. It seems this was incorrectly optimised by Prettier when porting the codebase. This is to prevent the script running on older browsers and ensures a runtime exception doesn't bubble up to the parent page. 