### PR TITLE
Guard library initialisation in failure modes 

### DIFF
--- a/src/scout.js
+++ b/src/scout.js
@@ -30,7 +30,9 @@ function init() {
   script.src = config.build;
 
   script.onload = () => {
-    FASTLY.init(config);
+    if (typeof FASTLY.init === "function") {
+      FASTLY.init(config);
+    }
   };
 
   baseScript.parentNode.insertBefore(script, baseScript);

--- a/test/scout.spec.js
+++ b/test/scout.spec.js
@@ -11,13 +11,16 @@ function load() {
 
 describe("Scout", () => {
   let _insertBefore;
+  let lib;
 
   beforeEach(() => {
     _insertBefore = document.body.insertBefore;
-    document.body.insertBefore = chai.spy();
+    const insertBeforeHandler = s => (lib = s);
+    document.body.insertBefore = chai.spy(insertBeforeHandler);
   });
 
   afterEach(() => {
+    lib = null;
     document.body.insertBefore = _insertBefore;
     const script = document.getElementById("fastlyjs");
     document.body.removeChild(script);
@@ -46,6 +49,18 @@ describe("Scout", () => {
       // Forcing assertion to be async due to setTimeout in the script
       setTimeout(() => {
         expect(document.body.insertBefore).to.have.been.called();
+        done();
+      }, 0);
+    });
+  });
+
+  it("should invoke the library init method if it exists", done => {
+    load().then(() => {
+      // Forcing assertion to be async due to setTimeout in the script
+      setTimeout(() => {
+        window.FASTLY.init = chai.spy();
+        lib.onload();
+        expect(window.FASTLY.init).to.have.been.called();
         done();
       }, 0);
     });


### PR DESCRIPTION
### TL;DR
Adds a guard around the initialisation of the library inside the scout file to ensure that the library has been loaded and the method exists before trying to invoke it.

### Why?
Resilience. The networking for the library may have failed, the library may have error during paring etc. This ensures we don't throw an error to the parent page.

Thank you to @dennismartensson for reporting the issue.