### PR TITLE
Fix resource-timing race causing an uncaught promise exception 

### DIFF
--- a/src/tasks/pop/index.js
+++ b/src/tasks/pop/index.js
@@ -35,11 +35,9 @@ class Pop extends Task {
 
   run() {
     let subjectId;
-    const resourceEntryPromise = asyncGetEntry(this.url);
 
-    return this.fetchObjectAndId()
-      .then(id => (subjectId = id))
-      .then(() => resourceEntryPromise)
+    return Promise.all([this.fetchObjectAndId(), asyncGetEntry(this.url)])
+      .then(([id, entry]) => (subjectId = id) && entry)
       .then(normalizeEntry)
       .then(timing => {
         const meta = { id: subjectId, attempted_id: this.config.id };


### PR DESCRIPTION
### TL;DR
Refactors the promise chain logic within the POP task to ensure exceptions thrown from the resource-timing `asyncGetEntry()` function don't bubble as uncaught. 

### Why?
We have observed a large number of uncaught exceptions being reported by user-agents with the error message `Timed out observing resource timing` which is thrown by the [`src/lib/resource-timing.js`](https://github.com/fastly/insights.js/blob/master/src/lib/resource-timing.js#L8-L35) library. As the invocation of this promise was called before being used the error may happen before the later `catch()` exception handler was attached to the chain. Thus causing the error to bubble to the parent document. 

### How
Refactoring the promise logic in the calling task will ensure the exception is appropriately caught and handled by the task runner.   

I have tested the changes to ensure the application still reports in the test environment across a range of browsers. 