### PR TITLE
Move hosts configuration out of server object and into settings object

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,15 +3,15 @@ const devConfig = {
   session: "header.payload.signature",
   settings: {
     customer_id: "1",
-    sample: 1
-  },
-  build: "http://localhost:3001/dist/lib.js",
-  server: {
+    sample: 1,
     hosts: {
       host: "staging.fastly-insights.com",
       lookup: "u.staging.eu.fastly-insights.com",
       pop: "pops.staging.fastly-insights.com"
-    },
+    }
+  },
+  build: "http://localhost:3001/dist/lib.js",
+  server: {
     datacenter: "LHR"
   },
   pops: [

--- a/src/runner.js
+++ b/src/runner.js
@@ -46,7 +46,7 @@ export default class Runner {
 
     // Assign config
     this.config = config;
-    this.config.hosts = config.server.hosts;
+    this.config.hosts = config.settings.hosts;
 
     // Generate task list
     const defaultTasks = config.tasks || [];

--- a/test/runner.spec.js
+++ b/test/runner.spec.js
@@ -45,7 +45,7 @@ const tasksFixture = {
 };
 
 const configFixture = {
-  server: {
+  settings: {
     host: "LHR"
   },
   tasks: [{ type: "defaultTask", id: "d" }]


### PR DESCRIPTION
### TL;DR
Move the `hosts` configuration object out of the global `config.server` object and into the `config.settings` object. So the path is now `config.settings.hosts`.

### Why?
Since #6 we have been incorrectly sending the `hosts` data along with every beacon as it was in the `config.server` object which contains other useful data required for analysis such as `server.datacenter`. This correctly separates the concerns by moving the data to settings, which is the correct classification.