### PR TITLE
Do-Not-Track opt-in setting

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@ const devConfig = {
   settings: {
     customer_id: "1",
     sample: 1,
+    dnt: false,
     hosts: {
       host: "staging.fastly-insights.com",
       lookup: "u.staging.eu.fastly-insights.com",

--- a/src/lib/dnt.js
+++ b/src/lib/dnt.js
@@ -1,0 +1,20 @@
+const getDNT = () => {
+  const hasWindowDNT = "doNotTrack" in window;
+  const hasNavigatorDNT = "doNotTrack" in navigator;
+
+  let val;
+
+  if (hasNavigatorDNT) {
+    val = navigator.doNotTrack;
+  } else if (hasWindowDNT) {
+    val = window.doNotTrack;
+  } else {
+    val = "0";
+  }
+
+  return ["yes", "1"].includes(val);
+};
+
+const hasDNT = getDNT();
+
+export default hasDNT;

--- a/src/scout.js
+++ b/src/scout.js
@@ -1,5 +1,6 @@
 /* global config */
 import hasProp from "./util/has";
+import hasDNT from "./lib/dnt";
 
 const cutsTheMustard = (config.ctm =
   hasProp(window, "Promise") &&
@@ -38,7 +39,11 @@ function init() {
   baseScript.parentNode.insertBefore(script, baseScript);
 }
 
-if (cutsTheMustard && isWithinSample(config.settings.sample)) {
+if (
+  cutsTheMustard &&
+  !(hasDNT && config.settings.dnt) &&
+  isWithinSample(config.settings.sample)
+) {
   loadWhenReady(() => setTimeout(init, config.settings.delay || 0));
 }
 

--- a/test/scout.spec.js
+++ b/test/scout.spec.js
@@ -97,6 +97,25 @@ describe("Scout", function() {
       }));
   });
 
+  describe("DNT", () => {
+    let _doNotTrack;
+
+    before(() => {
+      window.FASTLY = { config: { settings: { dnt: true } } };
+      _doNotTrack = window.doNotTrack;
+      window.doNotTrack = true;
+    });
+
+    after(() => {
+      window.doNotTrack = _doNotTrack;
+    });
+
+    it("should not inject script if Do Not Track setting is enabled", () =>
+      load().then(() => {
+        expect(document.body.insertBefore).to["not"].have.been.called();
+      }));
+  });
+
   describe("delayed load", () => {
     before(() => {
       window.FASTLY = { config: { settings: { sample: 1, delay: 1 } } };


### PR DESCRIPTION
### TL;DR
Adds logic to scout.js to read Do-Not-Track opt-ing form the server settings query object and user preference form the window and decide whether to load the script. This will allow sites embedding the script to configure whether they want the user DNT preference to be enforced.

### Why?
We want to be good internet citizens. Whilst the insights.js script does not collect personally identifiable data, we recognise that some people enable this setting in an effort to stop sites collecting any data at all. This has come up in discussions with early beta users of the script.

Therefore, to ensure we respect the intentions of end-users and users of the script we are allowing the functionality to be configurable via a query param`?dnt=true` which gets reflected in the settings object. 

We currently do not run the script if DNT is enabled, however after this change we will default to always collecting and embedding websites can disable the functionality via this query param if they wish. 

### How?
It reads the setting configured from by the host website form query parameter and the user preference from the `doNotTrack` api and prevents the library from running if both are true.