### PR TITLE
Add new fetch task

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,29 @@ The following table lists each of the possible tasks Fastly Insights may run on 
                 </ul>
             </td>
         </tr>
+        <tr>
+            <td>Fetch</td>
+            <td>Intended to measure the performance characteristics of a Fastly Insights owned HTTP endpoint. For experimentation and diagnostic purposes.</td>
+            <td>
+                <ul>
+                    <li><a href="https://w3c.github.io/resource-timing/#performanceresourcetiming">network timing</a></li>
+                    <li><a href="https://w3c.github.io/server-timing/">server timging</a></li>
+                    <li>network characteristics</li>
+                    <li>browser type (<a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent">User-Agent header</a> value is automatically normalized to browser vendor and version)</li>
+                    <li>DNS recursive resolver</li>
+                    <li>operating system</li>
+                <ul>
+            </td>
+            <td>
+                <ul>
+                    <li>anonymized Internet Protocol (IP) addresses (client IP addresses are automatically truncated to a /28 network prefix for IPv4 and /58 for IPv6 addresses)</li>
+                    <li>country or city-level geographic location</li>
+                    <li>date/time stamps</li>
+                    <li>network characteristics unique to the client connection</li>
+                    <li>browser capabilities: TLS protocol and cipher suites</li>
+                </ul>
+            </td>
+        </tr>
     </tbody>
 </table>
 

--- a/config.js
+++ b/config.js
@@ -14,6 +14,7 @@ const devConfig = {
   server: {
     datacenter: "LHR"
   },
+  tasks: [],
   pops: [
     {
       neighbours: ["YUL", "ORD", "JFK", "MSP"],
@@ -1287,6 +1288,7 @@ const prod = `
 		settings: '<% CONFIG %>',
 		build: '<% BUILD %>',
 		server: '<% SERVER %>',
+        tasks: '<% TASKS %>',
 		pops: '<% POPS %>'
 	};
 `;
@@ -1297,6 +1299,7 @@ const esi = {
   config: '<esi:include src="/esi/js/config.json" />',
   build: '<esi:include src="/esi/js/build.js" />',
   server: '<esi:include src="/esi/js/server.js" />',
+  tasks: '<esi:include src="/esi/js/tasks.json" />',
   pops: '<esi:include src="/esi/js/neighbours.json" />'
 };
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -61,6 +61,7 @@ function generateConfig({
                 '"<% CONFIG %>"': config.esi.config,
                 '"<% BUILD %>"': config.esi.build,
                 '"<% SERVER %>"': config.esi.server,
+                '"<% TASKS %>"': config.esi.tasks,
                 '"<% POPS %>"': config.esi.pops
               }
             })

--- a/src/tasks/fetch/index.js
+++ b/src/tasks/fetch/index.js
@@ -1,0 +1,30 @@
+import assign from "../../util/assign";
+import prefixKeys from "../../util/prefix-keys";
+
+import Task from "../task";
+import { asyncGetEntry, normalizeEntry } from "../../lib/resource-timing";
+
+class Fetch extends Task {
+  constructor(config) {
+    super(config);
+    this.url = `https://${this.config.host}/o.svg?u=${this.config.testId}`;
+    this.url = this.url.toLowerCase();
+  }
+
+  fetchObjectAndId() {
+    return fetch(this.url).then(res => res.headers.get("X-Datacenter"));
+  }
+
+  run() {
+    let subjectId;
+
+    return Promise.all([this.fetchObjectAndId(), asyncGetEntry(this.url)])
+      .then(([id, entry]) => (subjectId = id) && entry)
+      .then(normalizeEntry)
+      .then(timing =>
+        prefixKeys(assign({ id: subjectId }, timing), "subject_")
+      );
+  }
+}
+
+export default Fetch;

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -1,3 +1,2 @@
-import Pop from "./pop/index";
-
-export { Pop as pop };
+export { default as pop } from "./pop";
+export { default as fetch } from "./fetch";

--- a/src/tasks/pop/index.js
+++ b/src/tasks/pop/index.js
@@ -1,4 +1,5 @@
 import assign from "../../util/assign";
+import prefixKeys from "../../util/prefix-keys";
 
 import Task from "../task";
 import { transform as popsToTasks } from "./configure-tasks";
@@ -26,13 +27,6 @@ class Pop extends Task {
     return fetch(this.url).then(res => res.headers.get("X-Datacenter"));
   }
 
-  prefixKeys(obj, prefix) {
-    return Object.keys(obj).reduce((clone, key) => {
-      clone[prefix + key] = obj[key];
-      return clone;
-    }, {});
-  }
-
   run() {
     let subjectId;
 
@@ -41,7 +35,7 @@ class Pop extends Task {
       .then(normalizeEntry)
       .then(timing => {
         const meta = { id: subjectId, attempted_id: this.config.id };
-        const data = this.prefixKeys(assign(meta, timing), "subject_");
+        const data = prefixKeys(assign(meta, timing), "subject_");
         return data;
       });
   }

--- a/src/util/prefix-keys.js
+++ b/src/util/prefix-keys.js
@@ -1,0 +1,8 @@
+const prefixKeys = (obj, prefix) => {
+  return Object.keys(obj).reduce((clone, key) => {
+    clone[prefix + key] = obj[key];
+    return clone;
+  }, {});
+};
+
+export default prefixKeys;

--- a/test/tasks/fetch.spec.js
+++ b/test/tasks/fetch.spec.js
@@ -1,0 +1,75 @@
+import {
+  rewire$asyncGetEntry as getEntryRewire,
+  restore as getEntryRestore
+} from "../../src/lib/resource-timing";
+
+import Lib from "../../src/tasks/fetch/index.js";
+import testId from "../../src/lib/unique-id";
+import resourceFixture from "../fixtures/resource-timing-entry";
+
+const fixture = {
+  id: "test",
+  type: "fetch",
+  host: "test.com"
+};
+
+describe("Fetch", () => {
+  let task;
+  let mock;
+
+  before(() => {
+    mock = fetchMock.get({
+      name: "object-host",
+      method: "get",
+      response: {
+        body: "",
+        headers: {
+          "X-Datacenter": "LHR"
+        }
+      },
+      matcher: new RegExp(fixture.host)
+    });
+    getEntryRewire(() => Promise.resolve(resourceFixture));
+  });
+
+  beforeEach(() => {
+    task = new Lib(fixture);
+  });
+
+  afterEach(() => {
+    task = null;
+    mock.reset();
+  });
+
+  after(() => {
+    fetchMock.restore();
+    getEntryRestore();
+  });
+
+  it("should be a class", () => {
+    expect(Lib).to.be.an("function");
+    expect(new Lib(fixture)).to.be.an.instanceOf(Lib);
+  });
+
+  it("should make fetch request to provided hostname", () =>
+    task.run().then(() => {
+      expect(mock.done("object-host")).to.be.true;
+    }));
+
+  it("should ensure request is unique", () =>
+    task.run().then(() => {
+      const call = mock.lastCall("object-host")[0];
+      expect(call).to.contain(testId);
+    }));
+
+  it("should return the resource timing data for the request", () =>
+    task.run().then(({ subject_fetch_start }) => {
+      expect(subject_fetch_start).to.be.an("number");
+    }));
+
+  it("should return the subject_id from the response", () =>
+    task.run().then(({ subject_id }) => {
+      expect(subject_id).to.equal("LHR");
+      expect(subject_id).to.not.equal(fixture.id);
+    }));
+});

--- a/test/tasks/pop.spec.js
+++ b/test/tasks/pop.spec.js
@@ -84,19 +84,4 @@ describe("POP", () => {
       expect(subject_id).to.equal("LHR");
       expect(subject_id).to.not.equal(fixture.id);
     }));
-
-  describe("#prefixKeys", () => {
-    it("should prefix all keys of an object with a given string", () => {
-      const fixture = { foo: "bar" };
-      const result = task.prefixKeys(fixture, "baz_");
-
-      expect(result).to.have.property("baz_foo");
-      expect(result).to.not.have.property("foo");
-    });
-
-    it("should not mutate the original object", () => {
-      const fixture = Object.freeze({ foo: "bar" });
-      expect(task.prefixKeys.bind(null, fixture, "baz_")).to.not.throw();
-    });
-  });
 });

--- a/test/util/prefix-keys.spec.js
+++ b/test/util/prefix-keys.spec.js
@@ -1,0 +1,20 @@
+import lib from "../../src/util/prefix-keys";
+
+describe("Prefix keys", () => {
+  it("should be a function", () => {
+    expect(lib).to.be.an("function");
+  });
+
+  it("should prefix all keys of an object with a given string", () => {
+    const fixture = { foo: "bar" };
+    const result = lib(fixture, "baz_");
+
+    expect(result).to.have.property("baz_foo");
+    expect(result).to.not.have.property("foo");
+  });
+
+  it("should not mutate the original object", () => {
+    const fixture = Object.freeze({ foo: "bar" });
+    expect(lib.bind(null, fixture, "baz_")).to.not.throw();
+  });
+});


### PR DESCRIPTION
### TL;DR
Adds a new task type `fetch`, which is nearly identical to the existing `pop` task. This fetches a single object on a Fastly Insights owned hostname matching `*.fastly-insights.com` For experimentation and diagnostic purposes.

### Why?
We want to be able to compare timing from existing endpoints against new experimental 
so we can track their effectiveness. By performing this test on client runs it allows us to easily do this comparison. 

### How?
Create a single task which will only be run once per client to fetch an object from the Fastly Insights hostname such as `pdata.pops.fastly-insights.com` and record the datacenter which served the object and the associated resource timing information.

- Abstract the object `prefixKeys` logic shared between both tasks to a utility library
- Add `fetch` task and tests
- Add a tasks config placeholder, to allow the server to dynamically add the task when enabled.   
- Update readme to include new task
