### PR TITLE
Add task_id to base task result model

### DIFF
--- a/src/tasks/task.js
+++ b/src/tasks/task.js
@@ -29,7 +29,7 @@ class Task {
     beacon(url, data);
   }
 
-  generateResult({ testId, apiKey, server, type }, result, clientInfo) {
+  generateResult({ testId, apiKey, server, type, id }, result, clientInfo) {
     return assign(
       {
         test_id: testId,
@@ -38,6 +38,7 @@ class Task {
         test_server: JSON.stringify(server),
         test_timestamp: Math.floor(Date.now() / 1000), // Unix timestamp in seconds
         task_type: type,
+        task_id: id,
         task_schema_version: "0.0.0",
         task_client_data: JSON.stringify(result),
         task_server_data: "<% SERVER_DATA %>"

--- a/test/tasks/task.spec.js
+++ b/test/tasks/task.spec.js
@@ -120,6 +120,7 @@ describe("Task", () => {
       testId: "1234",
       apiKey: "1111",
       server: { host: "www.test.com" },
+      id: "iad",
       type: "test"
     };
     const resultFixture = { foo: "bar" };
@@ -152,6 +153,8 @@ describe("Task", () => {
       expect(result.test_server).to.equal(JSON.stringify(configFixture.server));
       expect(result).to.have.property("task_type");
       expect(result.task_type).to.equal("test");
+      expect(result).to.have.property("task_id");
+      expect(result.task_id).to.equal("iad");
     });
 
     it("should assign a unix timestamp property of the task run", () => {


### PR DESCRIPTION
### TL;DR
Adds `task_id` property to the task result model to ensure it gets sent as part of the beacon payload for all tasks. 

### Why?
This seems to have been missed originally as has always been documented as part of the task schema, however hasn't been an issue as we've only had one task type `pop`. As we introduce new task types such as `fetch` (see #18) we need a way to filter and query the beacon data by their `task_type` and unique `task_id` properties. 