### PR TITLE
Randomly shuffle task queue

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -1,5 +1,6 @@
 import assign from "./util/assign";
 import sequence from "./util/sequence";
+import shuffle from "./util/shuffle";
 
 export default class Runner {
   constructor(tasks) {
@@ -60,7 +61,10 @@ export default class Runner {
     const tasks = hydratedTasks.map(task => new Tasks[task.type](task));
 
     // Generate queue task of functions to run
-    this.taskQueue = tasks.map(task => () => task.execute());
+    const taskQueue = tasks.map(task => () => task.execute());
+
+    // Randomly shuffle taskQueue to avoid systematic bias
+    this.taskQueue = shuffle(taskQueue);
 
     // Run tasks!
     return this.run();

--- a/src/util/shuffle.js
+++ b/src/util/shuffle.js
@@ -1,0 +1,18 @@
+// Randomly shuffle an array in-place using Fisher–Yates Shuffle
+// https://bost.ocks.org/mike/shuffle/
+export default function shuffle(array) {
+  const a = [...array];
+  let m = a.length;
+  let t;
+  let i;
+
+  while (m) {
+    i = Math.floor(Math.random() * m--);
+
+    t = a[m];
+    a[m] = a[i];
+    a[i] = t;
+  }
+
+  return a;
+}


### PR DESCRIPTION
### TL;DR
This ensures that the global task queue is randomly shuffled before we sequentially execute the queue. This is avoid any systematic bias that _may_ be introduced due to ordering. 