### PR TITLE
Add promise retry utility

### DIFF
--- a/src/util/promiseRetry.spec.ts
+++ b/src/util/promiseRetry.spec.ts
@@ -1,0 +1,55 @@
+import retry from "./promiseRetry";
+
+jest.useFakeTimers();
+
+describe("promiseRetry", (): void => {
+  it("should retry the promise function if it rejected", (): Promise<void> => {
+    const mockFunc = jest.fn();
+
+    // Create a promise generating function that will
+    // finally resolve on third attempt.
+    mockFunc
+      .mockReturnValueOnce(Promise.reject(false))
+      .mockReturnValueOnce(Promise.reject(false))
+      .mockReturnValue(Promise.resolve(true));
+
+    // As we recurse the `wait` promise func which pushes a `setTimeout`
+    // onto the micro task queue, this is a horrible hack to get all
+    // fake timers on the task queue to advance after each tick.
+    Promise.resolve()
+      .then((): void => {})
+      .then((): void => {})
+      .then((): typeof jest => jest.runAllTimers())
+      .then((): void => {})
+      .then((): void => {})
+      .then((): typeof jest => jest.runAllTimers());
+
+    return retry(mockFunc, 4, 0).then(
+      (result): void => {
+        expect(result).toEqual(true);
+      }
+    );
+  });
+
+  it("should delay the retry by the supplied amount of time", (): Promise<
+    void
+  > => {
+    const mockFunc = jest.fn();
+    const delayFixture = 100;
+
+    mockFunc
+      .mockReturnValueOnce(Promise.reject(false))
+      .mockReturnValue(Promise.resolve(true));
+
+    Promise.resolve()
+      .then((): void => {})
+      .then((): void => {})
+      .then((): typeof jest => jest.advanceTimersByTime(delayFixture));
+
+    return retry(mockFunc, 2, delayFixture).then(
+      (result): void => {
+        expect(result).toEqual(true);
+      }
+    );
+  });
+});

--- a/src/util/promiseRetry.ts
+++ b/src/util/promiseRetry.ts
@@ -1,0 +1,33 @@
+type PromiseGenerator = <T>() => Promise<T>;
+
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY = 100;
+
+const wait = (delay: number): Promise<void> =>
+  new Promise((resolve): number => setTimeout(resolve, delay));
+
+function retry<T>(
+  func: PromiseGenerator,
+  times: number = DEFAULT_RETRY_ATTEMPTS,
+  delay: number = DEFAULT_RETRY_DELAY
+): Promise<T> {
+  return new Promise(
+    (resolve, reject): void => {
+      func<T>()
+        .then(resolve)
+        .catch(
+          (err: Error): Promise<any> | void => {
+            if (--times > 0) {
+              return wait(delay)
+                .then((): Promise<T> => retry<T>(func, times, delay))
+                .then(resolve)
+                .catch(reject);
+            }
+            return reject(err);
+          }
+        );
+    }
+  );
+}
+
+export default retry;


### PR DESCRIPTION
**⚠️ Note this is a PR into the v.2.0.0 branch and not master**

### TL;DR
Adds a utility function to retry a promise `n` times with a delay of `m` ms in-between each invocation. This will be used to retry tasks or individual fetch requests etc.

### Notes:
Due to the way the recursion works and how `setTimeout` is natievly mocked in Jest, i've had to do some hackery with the micro task queue to get the test working properly. But it works! See this SO answer from the Jest team for more detail: https://stackoverflow.com/a/51132058

### Example usage:
```js
import retry from './util/promiseRetry';

const retryDelay = 100;
const retryAttempts = 3;

const getConfig = () => fetch(url).then(r => r.json());

return retry(getConfig, retryAttempts, retryDelay)
```