### PR TITLE
Fetch config with API token

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,8 @@
                 debug: false,
                 exclude: [
                     "es.promise",
-                    "es.object.to-string"
+                    "es.object.to-string",
+                    "web.url"
                 ]
             }
         ],

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,8 @@ module.exports = {
   coverageDirectory: "coverage",
   moduleNameMapper: {
     "^workerize-loader": "<rootDir>/src/__mocks__/worker.ts"
+  },
+  globals: {
+    PRODUCTION: false
   }
 };

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -2,6 +2,10 @@ interface FetchResponse {
   json(): Promise<any>;
 }
 
+interface QueryParameters {
+  [key: string]: string;
+}
+
 //  Server response
 // ---------------------------------------------------------------------------
 

--- a/src/@types/worker.d.ts
+++ b/src/@types/worker.d.ts
@@ -1,9 +1,8 @@
 declare module "workerize-loader!*" {
   class WorkerizeWorker extends Worker {
     public constructor();
-    public init(): Promise<Config>;
+    public init(params: QueryParameters): Promise<Config>;
   }
 
-  export const mockInit: jest.Mock;
   export default WorkerizeWorker;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,12 @@
-// FIXME; Use real API location, whatever that is
-export const CONFIG_HOST = "https://api.fastly.com";
-export const CONFIG_PATH = "/api/url";
+// The ENV var is replaced at compile time via webpack.DefinePlugin
+declare const PRODUCTION: string;
+
+export const CONFIG_HOST = PRODUCTION
+  ? "https://www.fastly-insights.com"
+  : "https://test.fastly-insights.com";
+export const CONFIG_PATH = "/api/v1/config/";
 export const CLIENT_INFO_PATH = "/client-info";
 export const CONFIG_URL = `${CONFIG_HOST}${CONFIG_PATH}`;
+export const SCRIPT_SRC_REGEXP = PRODUCTION
+  ? /$https:\/\/www\.fastly-insights.com/
+  : /\/main/;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
+import { SCRIPT_SRC_REGEXP } from "./constants";
 import { hasProperties } from "./util/object";
 import loadWhenDocumentReady from "./util/loadWhenDocumentReady";
+import getScriptParameters from "./util/scriptQueryParameters";
 import Worker from "workerize-loader!./worker";
 
 // List of required features browser features
@@ -18,8 +20,9 @@ const state: Fastly = {
 export function init(): void {
   loadWhenDocumentReady(
     (): void => {
+      const params = getScriptParameters(SCRIPT_SRC_REGEXP);
       const worker = new Worker();
-      worker.init();
+      worker.init(params);
     }
   );
 }

--- a/src/util/promiseRetry.ts
+++ b/src/util/promiseRetry.ts
@@ -1,4 +1,4 @@
-type PromiseGenerator = <T>() => Promise<T>;
+// type PromiseGenerator = () => Promise<T>;
 
 const DEFAULT_RETRY_ATTEMPTS = 3;
 const DEFAULT_RETRY_DELAY = 100;
@@ -7,13 +7,13 @@ const wait = (delay: number): Promise<void> =>
   new Promise((resolve): number => setTimeout(resolve, delay));
 
 function retry<T>(
-  func: PromiseGenerator,
+  func: () => Promise<T>,
   times: number = DEFAULT_RETRY_ATTEMPTS,
   delay: number = DEFAULT_RETRY_DELAY
 ): Promise<T> {
-  return new Promise(
+  return new Promise<T>(
     (resolve, reject): void => {
-      func<T>()
+      func()
         .then(resolve)
         .catch(
           (err: Error): Promise<any> | void => {

--- a/src/util/scriptQueryParameters.spec.ts
+++ b/src/util/scriptQueryParameters.spec.ts
@@ -1,0 +1,51 @@
+import scriptQueryParameters from "./scriptQueryParameters";
+
+function createScriptElement(src: string): void {
+  const el = document.createElement("script");
+  el.src = src;
+  document.body.appendChild(el);
+}
+
+function removeScriptElement(src: string): void {
+  const scripts: Element[] = [...document.getElementsByTagName("script")];
+  const script: Element | undefined = scripts.find(
+    (s): boolean => s.getAttribute("src") === src
+  );
+  if (script instanceof Element) {
+    document.body.removeChild(script);
+  }
+}
+
+describe("scriptQueryParameters", (): void => {
+  it("should return empty object if no script tag is found", (): void => {
+    const result = scriptQueryParameters(/foo/);
+    expect(result).toEqual({});
+  });
+
+  it("should return query parameters as object", (): void => {
+    const tests = [
+      {
+        src: "https://test.com/path?foo=bar",
+        matcher: /test\.com/,
+        expected: {
+          foo: "bar"
+        }
+      },
+      {
+        src: "https://test.com/path?foo=bar&baz=qux%20qaz",
+        matcher: /test\.com/,
+        expected: {
+          foo: "bar",
+          baz: "qux qaz"
+        }
+      }
+    ];
+
+    for (const test of tests) {
+      createScriptElement(test.src);
+      const result = scriptQueryParameters(test.matcher);
+      expect(result).toEqual(test.expected);
+      removeScriptElement(test.src);
+    }
+  });
+});

--- a/src/util/scriptQueryParameters.ts
+++ b/src/util/scriptQueryParameters.ts
@@ -1,0 +1,30 @@
+const getElements = (element: string): Element[] =>
+  [].slice.call(document.getElementsByTagName(element));
+const elementHasSource = (el: Element): boolean => el.hasAttribute("src");
+const getSrc = (el: Element): string => el.getAttribute("src") || "";
+
+export default function getParameters(srcRegExp: RegExp): QueryParameters {
+  const script = getElements("script")
+    .filter(elementHasSource)
+    .find((s): boolean => !!getSrc(s).match(srcRegExp));
+
+  let result: QueryParameters = {};
+
+  if (script) {
+    const src = getSrc(script);
+    const url = new URL(src);
+
+    result = Array.from(url.searchParams.entries()).reduce(
+      (
+        res: QueryParameters,
+        [key, value]: [string, string]
+      ): QueryParameters => {
+        res[key] = value;
+        return res;
+      },
+      {}
+    );
+  }
+
+  return result;
+}

--- a/src/worker.spec.ts
+++ b/src/worker.spec.ts
@@ -4,20 +4,25 @@ import configFixture from "./fixtures/config";
 import { init } from "./worker";
 import nock from "nock";
 
+const queryParametersFixture = {
+  k: "2e8a8c19-e1c6-4d68-9200-d6a894b39414"
+};
+
 describe("worker", (): void => {
   describe("init", (): void => {
     it("should return a promise for all tasks", (): Promise<void> => {
-      const token = configFixture.settings.token;
+      const { k: token } = queryParametersFixture;
+
       nock(`https://${token}.eu.u.test.fastly-insights.com`)
         .defaultReplyHeaders({ "access-control-allow-origin": "*" })
         .get("/l")
         .reply(200, clientInfoFixture);
       nock(CONFIG_HOST)
         .defaultReplyHeaders({ "access-control-allow-origin": "*" })
-        .get(CONFIG_PATH)
+        .get(CONFIG_PATH + token)
         .reply(200, configFixture);
 
-      return init().then(
+      return init(queryParametersFixture).then(
         (beacons: Beacon[]): void => {
           for (let i = 0; i < beacons.length; i++) {
             const beacon = beacons[i];

--- a/webpack.HtmlApiTokenWebpackPlugin.js
+++ b/webpack.HtmlApiTokenWebpackPlugin.js
@@ -1,0 +1,31 @@
+class HtmlApiTokenPlugin {
+  constructor({ apiToken }) {
+    this.apiToken = apiToken;
+  }
+
+  getMainTag(data) {
+    return data.body.find(t => t.attributes.src.match(/\/main/));
+  }
+
+  getSrc(tag) {
+    return tag.attributes.src;
+  }
+
+  srcWithToken(src) {
+    return `${src}?k=${this.apiToken}`;
+  }
+
+  apply(compiler) {
+    compiler.hooks.compilation.tap('HtmlApiTokenPlugin', (compilation) => {
+      compilation.hooks.htmlWebpackPluginAlterAssetTags.tap(
+        'HtmlApiTokenPlugin', (data) => {
+          const tag = this.getMainTag(data);
+          const src = this.getSrc(tag);
+          tag.attributes.src = this.srcWithToken(src);
+        }
+      )
+    })
+  }
+}
+
+module.exports = HtmlApiTokenPlugin;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -2,6 +2,9 @@ const path = require('path');
 
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HtmlApiTokenWebpackPlugin = require('./webpack.HtmlApiTokenWebpackPlugin.js');
+
+const DEV_API_TOKEN = "2e8a8c19-e1c6-4d68-9200-d6a894b39414";
 
 module.exports = {
   entry: './src/index.ts',
@@ -31,7 +34,10 @@ module.exports = {
     new HtmlWebpackPlugin({
       title: 'Insights.js',
       template: path.resolve(__dirname, 'src', 'index.html')
-    })
+    }),
+    new HtmlApiTokenWebpackPlugin({
+      apiToken: DEV_API_TOKEN
+    }),
   ],
   output: {
     library: 'FASTLY',

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
@@ -12,6 +13,11 @@ module.exports = merge(common, {
     port: 8000,
     open: true
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      PRODUCTION: 'false'
+    })
+  ],
   output: {
     globalObject: 'this'
   }

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -22,6 +22,9 @@ module.exports = merge(common, {
       }),
       new BundleAnalyzerPlugin({
          analyzerMode: 'static'
+      }),
+      new webpack.DefinePlugin({
+         PRODUCTION: 'true'
       })
    ],
    output: {


### PR DESCRIPTION
**⚠️ Note this is a PR into the v.2.0.0 branch and not master**

### TL;DR
Adds utilities to parse the API token from the script tag `src` url and pass to `Worker.init()` to fetch the config from API. 

### Why?
As we are no longer dynamically transcluding the API token into the JavaScript at the edge (thus allowing for the same script for all consumers), we need to obtain it from the script tag, i,.e. from `<script defer src="https://www.fastly-insights.com/insights.js?k=1-2-3-4"></script>`. Therefore we have to use a utility to find the tag and parse out the parameters. 

### Notes:
- Due to browser support and the size of the polyfill, we can't just use the newer URL interface: `let params = (new URL(src)).searchParams;` and have opted for writing a custom util. https://github.com/fastly/insights.js/commit/51aec8633075d9233294bb33dfe7f171a38fc155
- It seems that the the `HtmlWebpackPlugin` doesn't allow you to easily add query parameters to the chunk urls nor are there any other plugins that allow this. Therefore I had to write my own for this behaviour in https://github.com/fastly/insights.js/commit/bb7c3e316d1b57b4300852f78f12db2aae0b0ae2
- I've now added the correct API hostname and paths and therefore also added a `PRODUCTION` global via webpack `DefinePlugin`. The nice thing about this is the noop gets compiled away at compile time and therefore the final bundle only have the value for that environment. 