### PR TITLE
Production `publicPath`

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -28,6 +28,6 @@ module.exports = merge(common, {
       })
    ],
    output: {
-    publicPath: '/static/'
+      publicPath: 'https://www.fastly-insights.com/static/'
    }
 });


### PR DESCRIPTION
**⚠️ Note this is a PR into the v.2.0.0 branch and not master**

### TL;DR
Sets the correct public asset path for webpack in production. 