### PR TITLE
Refactor worker config initialisation

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,5 +8,5 @@ export const CONFIG_PATH = "/api/v1/config/";
 export const CLIENT_INFO_PATH = "/client-info";
 export const CONFIG_URL = `${CONFIG_HOST}${CONFIG_PATH}`;
 export const SCRIPT_SRC_REGEXP = PRODUCTION
-  ? /$https:\/\/www\.fastly-insights.com/
+  ? /^https:\/\/[a-z]+\.fastly-insights\.com/
   : /\/main/;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,12 +1,9 @@
-// The ENV var is replaced at compile time via webpack.DefinePlugin
-declare const PRODUCTION: string;
+// This is declared via Webpack DefinePlugin at compile time
+declare const PRODUCTION: boolean;
 
-export const CONFIG_HOST = PRODUCTION
-  ? "https://www.fastly-insights.com"
-  : "https://test.fastly-insights.com";
+export const CONFIG_HOST = "https://test.fastly-insights.com";
 export const CONFIG_PATH = "/api/v1/config/";
 export const CLIENT_INFO_PATH = "/client-info";
-export const CONFIG_URL = `${CONFIG_HOST}${CONFIG_PATH}`;
 export const SCRIPT_SRC_REGEXP = PRODUCTION
   ? /^https:\/\/[a-z]+\.fastly-insights\.com/
   : /\/main/;

--- a/src/util/scriptQueryParameters.spec.ts
+++ b/src/util/scriptQueryParameters.spec.ts
@@ -30,7 +30,8 @@ describe("scriptQueryParameters", (): void => {
         src: "https://test.com/path?foo=bar",
         matcher: /test\.com/,
         expected: {
-          foo: "bar"
+          foo: "bar",
+          host: "https://test.com"
         }
       },
       {
@@ -38,7 +39,8 @@ describe("scriptQueryParameters", (): void => {
         matcher: /test\.com/,
         expected: {
           foo: "bar",
-          baz: "qux qaz"
+          baz: "qux qaz",
+          host: "https://test.com"
         }
       }
     ];

--- a/src/util/scriptQueryParameters.ts
+++ b/src/util/scriptQueryParameters.ts
@@ -14,6 +14,9 @@ export default function getParameters(srcRegExp: RegExp): QueryParameters {
     const src = getSrc(script);
     const url = new URL(src);
 
+    // Also return the full hostname so we can use for configuration.
+    result.host = url.origin;
+
     // We can't use url.searchParams.entries().reduce() here as lib.d.ts
     // doesn't declare the entries iterable type on the object :(
     url.searchParams.forEach(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,10 +1,13 @@
 import "unfetch/polyfill";
-import { CONFIG_URL } from "./constants";
+import { CONFIG_PATH } from "./constants";
 import chooseRandomTasks from "./lib/chooseRandomTasks";
 import retry from "./util/promiseRetry";
 import sequence from "./util/promiseSequence";
 import { create as createTask } from "./tasks";
 import Task from "./tasks/task";
+
+// This is declared via Webpack DefinePlugin at compile time
+declare const PRODUCTION: boolean;
 
 function runTasks(configuration: Config): Promise<Beacon[]> {
   const {
@@ -29,8 +32,12 @@ function getConfig(url: string): Promise<Config> {
   return retry(fetchJSON);
 }
 
-export function init({ k: apiToken }: QueryParameters): Promise<Beacon[]> {
-  const configUrl = `${CONFIG_URL}${apiToken}`;
+export function init({
+  host,
+  k: apiToken
+}: QueryParameters): Promise<Beacon[]> {
+  const configHost = PRODUCTION ? host : "https://test.fastly-insights.com";
+  const configUrl = `${configHost}${CONFIG_PATH}${apiToken}`;
   return getConfig(configUrl)
     .then(runTasks)
     .catch(


### PR DESCRIPTION
**⚠️ Note this is a PR into the v.2.0.0 branch and not master**

### TL;DR
Refactors the worker configuration initialisation to read config hostname from script tag in production and pre-production environment. 