### PR TITLE
Load worker as a normal synchronous module

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,6 @@
 module.exports = {
   clearMocks: true,
   coverageDirectory: "coverage",
-  moduleNameMapper: {
-    "^workerize-loader": "<rootDir>/src/__mocks__/worker.ts"
-  },
   globals: {
     PRODUCTION: false
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10006,15 +10006,6 @@
         "errno": "~0.1.7"
       }
     },
-    "workerize-loader": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/workerize-loader/-/workerize-loader-1.0.4.tgz",
-      "integrity": "sha512-HMTr/zpuZhm8dbhcK52cMYmn57uf7IJeMZJil+5lL/vC5+AO9wzxZ0FISkGVj78No7HcpaINwAWHGCYx3dnsTw==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0"
-      }
-    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "webpack-bundle-analyzer": "^3.3.2",
     "webpack-cli": "^3.3.2",
     "webpack-dev-server": "^3.4.1",
-    "webpack-merge": "^4.2.1",
-    "workerize-loader": "^1.0.4"
+    "webpack-merge": "^4.2.1"
   },
   "dependencies": {
     "@fastly/performance-observer-polyfill": "^1.0.2"

--- a/src/__mocks__/worker.ts
+++ b/src/__mocks__/worker.ts
@@ -1,4 +1,3 @@
-export default class Worker {
-  public constructor() {}
-  public init(): void {}
-}
+const init = jest.fn().mockReturnValue(Promise.resolve());
+
+export { init };

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,23 +1,12 @@
 import state, { init } from "./index";
-import Worker from "workerize-loader!./worker";
+import * as worker from "./worker";
 
-const mockInit = jest.fn();
-jest.mock(
-  "workerize-loader!./worker",
-  (): jest.Mock => {
-    return jest.fn().mockImplementation(
-      (): any => {
-        return { init: mockInit };
-      }
-    );
-  }
-);
+jest.mock("./worker");
 
 describe("index", (): void => {
   beforeAll(
     (): void => {
-      (Worker as jest.Mock).mockClear();
-      mockInit.mockClear();
+      (worker.init as jest.Mock).mockClear();
     }
   );
 
@@ -35,8 +24,7 @@ describe("index", (): void => {
   describe("init", (): void => {
     it("should invoke the woker init method when ready", (): void => {
       init();
-      expect(Worker).toHaveBeenCalled();
-      expect(mockInit).toHaveBeenCalled();
+      expect(worker.init).toHaveBeenCalled();
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { SCRIPT_SRC_REGEXP } from "./constants";
 import { hasProperties } from "./util/object";
 import loadWhenDocumentReady from "./util/loadWhenDocumentReady";
 import getScriptParameters from "./util/scriptQueryParameters";
-import Worker from "workerize-loader!./worker";
+import * as worker from "./worker";
 
 // List of required features browser features
 const requiredFeatures = ["Worker", "Promise", "fetch"];
@@ -21,8 +21,7 @@ export function init(): void {
   loadWhenDocumentReady(
     (): void => {
       const params = getScriptParameters(SCRIPT_SRC_REGEXP);
-      const worker = new Worker();
-      worker.init(params);
+      worker.init(params).catch((): void => {});
     }
   );
 }


### PR DESCRIPTION
**⚠️ Note this is a PR into the v.2.0.0 branch and not master**

### TL;DR
Due to the cross-origin loading restrictions of `WebWorkers` this refactors the scout script to load the worker library as a normal synchronous module inline, instead of instantiating a new `WebWorker` with the library. This is hopefully a temporary measure until we can iron out the related issues. 

### Why?
I was unaware of the tighter same-origin restrictions of WebWorkers, regardless of CORS headers or the normal cross-origin rules within browsers. Therefore, when v2.0.0 of the library was loaded as a 3rd party we were observing errors stating the worker was prevented from loading due to cross-origin restrictions.

It is possible to load cross origin web workers via an inline `Blob` URL, such as  `new Worker(URL.createObjectURL(new Blob(script))`. However, this requires the `blob:` scheme to be allowed via the host documents `Content-Security-Policy`, which isn't currently the case for some of our production users.

I hope for this to be a temporary stop-gap until we decide a path forward with workers. I am currently considering making the feature opt-in and available via a query parameter, which if present will load the library as a cross-origin worker via `Blob` and dynamically load as main-thread module if not. 