### PR TITLE
Task classification

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -6,6 +6,13 @@ interface QueryParameters {
   [key: string]: string;
 }
 
+//  Classifiers
+// ---------------------------------------------------------------------------
+type CountryCode = string;
+type ASN = number;
+type ConnectionType = string;
+type DeviceType = string;
+
 //  Server response
 // ---------------------------------------------------------------------------
 
@@ -13,12 +20,20 @@ interface Test {
   id: string;
 }
 
-interface Client {
+interface Agent {
   hasFeatureSupport: boolean;
 }
 
+interface Client {
+  country_code: CountryCode;
+  connection_type: ConnectionType;
+  asn: ASN;
+  device_type: DeviceType;
+  [key: string]: string | number;
+}
+
 interface Fastly {
-  client: Client;
+  client: Agent;
 }
 
 interface Host {
@@ -40,6 +55,14 @@ interface Server {
 
 // Config/tasks
 // ---------------------------------------------------------------------------
+interface TaskClassification {
+  country_code?: CountryCode[];
+  asn?: ASN[];
+  connection_type?: ConnectionType[];
+  device_type?: DeviceType[];
+  [key: string]: string[] | number[] | undefined;
+}
+
 interface TaskData {
   id: string;
   req_header: string;
@@ -47,15 +70,17 @@ interface TaskData {
   resp_header: string;
   type: string;
   weight: number;
+  classification: TaskClassification;
 }
 
 interface Config {
-  test: Test;
-  session: string;
+  client: Client;
   hosts: Host;
-  settings: Settings;
   server: Server;
+  session: string;
+  settings: Settings;
   tasks: TaskData[];
+  test: Test;
 }
 
 interface TaskInterface {

--- a/src/fixtures/config.ts
+++ b/src/fixtures/config.ts
@@ -17,6 +17,12 @@ const configFixture: Config = {
     sample_rate: 0.4,
     token: "d00fe9b6-91c6-4434-8e77-14630e263a26"
   },
+  client: {
+    country_code: "GB",
+    asn: 5089,
+    connection_type: "broadband",
+    device_type: "unknown"
+  },
   server: {
     datacenter: "LCY"
   },
@@ -27,7 +33,8 @@ const configFixture: Config = {
       resource: "https://mad-v4.pops.test.fastly-insights.com/o.svg",
       resp_header: "",
       type: "pop",
-      weight: 3.23
+      weight: 3.23,
+      classification: {}
     },
     {
       id: "LCY",
@@ -35,7 +42,8 @@ const configFixture: Config = {
       resource: "https://lcy-v4.pops.test.fastly-insights.com/o.svg",
       resp_header: "",
       type: "pop",
-      weight: 1.01
+      weight: 1.01,
+      classification: {}
     },
     {
       id: "rtt",
@@ -43,7 +51,8 @@ const configFixture: Config = {
       resource: "https://www.fastly-insights.com/rtt.json",
       resp_header: "",
       type: "fetch",
-      weight: 1
+      weight: 1,
+      classification: {}
     }
   ]
 };

--- a/src/lib/filterTasksByClientClassification.spec.ts
+++ b/src/lib/filterTasksByClientClassification.spec.ts
@@ -1,0 +1,88 @@
+import filterClassifiedTasks from "./filterTasksByClientClassification";
+
+/* eslint-disable @typescript-eslint/camelcase */
+const clientFixture = {
+  country_code: "GB",
+  asn: 5089,
+  connection_type: "broadband",
+  device_type: "unknown"
+};
+
+const tasksFixture = [
+  {
+    id: "test1",
+    type: "fetch",
+    resource: "https://test.fastly-insights.com/1.svg",
+    weight: 1,
+    req_header: "",
+    resp_header: "",
+    classification: {
+      asn: undefined
+    }
+  },
+  {
+    id: "test2",
+    type: "fetch",
+    resource: "https://test.fastly-insights.com/2.svg",
+    weight: 1,
+    req_header: "",
+    resp_header: "",
+    classification: {
+      country_code: ["DE"]
+    }
+  },
+  {
+    id: "test3",
+    type: "fetch",
+    resource: "https://test.fastly-insights.com/3.svg",
+    weight: 1,
+    req_header: "",
+    resp_header: "",
+    classification: {
+      country_code: ["GB", "US", "DE"],
+      asn: [5089]
+    }
+  }
+];
+/* eslint-enable @typescript-eslint/camelcase */
+
+describe("filterTasksByClientClassification", (): void => {
+  it("should filter tasks by their client classification", (): void => {
+    const result = filterClassifiedTasks(tasksFixture, clientFixture);
+
+    // Should filter test2 out of fixture as country_code doesn't match
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "classification": Object {
+            "asn": undefined,
+          },
+          "id": "test1",
+          "req_header": "",
+          "resource": "https://test.fastly-insights.com/1.svg",
+          "resp_header": "",
+          "type": "fetch",
+          "weight": 1,
+        },
+        Object {
+          "classification": Object {
+            "asn": Array [
+              5089,
+            ],
+            "country_code": Array [
+              "GB",
+              "US",
+              "DE",
+            ],
+          },
+          "id": "test3",
+          "req_header": "",
+          "resource": "https://test.fastly-insights.com/3.svg",
+          "resp_header": "",
+          "type": "fetch",
+          "weight": 1,
+        },
+      ]
+    `);
+  });
+});

--- a/src/lib/filterTasksByClientClassification.ts
+++ b/src/lib/filterTasksByClientClassification.ts
@@ -1,0 +1,24 @@
+export default function filterTasksByClientClassification(
+  tasks: TaskData[],
+  client: Client
+): TaskData[] {
+  return tasks.filter(
+    ({ classification }): boolean => {
+      return Object.keys(classification).reduce<boolean>(
+        (acc, key): boolean => {
+          const classifiers = classification[key];
+          if (classifiers) {
+            return (
+              acc &&
+              classifiers.some(
+                (val: string | number): boolean => val === client[key]
+              )
+            );
+          }
+          return acc;
+        },
+        true
+      );
+    }
+  );
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,6 +1,7 @@
 import "unfetch/polyfill";
 import { CONFIG_PATH } from "./constants";
 import chooseRandomTasks from "./lib/chooseRandomTasks";
+import filterTasksByClientClassification from "./lib/filterTasksByClientClassification";
 import retry from "./util/promiseRetry";
 import sequence from "./util/promiseSequence";
 import { create as createTask } from "./tasks";
@@ -11,10 +12,12 @@ declare const PRODUCTION: boolean;
 
 function runTasks(configuration: Config): Promise<Beacon[]> {
   const {
+    client,
     settings: { max_tasks: maxTasks },
     tasks
   } = configuration;
-  const selectedTasks = chooseRandomTasks(tasks, maxTasks);
+  const possibleTasks = filterTasksByClientClassification(tasks, client);
+  const selectedTasks = chooseRandomTasks(possibleTasks, maxTasks);
   const hydratedTasks = selectedTasks.map(
     (taskData): Task => createTask(configuration, taskData)
   );


### PR DESCRIPTION
**⚠️ Note this is a PR into the v.2.0.0 branch and not master**

### TL;DR
Refactors the task running logic to initially filter tasks by their `classification` property comparing against the current client's classification. I.e. enables the library to only run tasks on a given connection type in a given network. For example this task would only run on the ASN `5089` in USA, Great Britain and Germany. 

```js
{
    id: "test",
    type: "fetch",
    resource: "https://test.fastly-insights.com/o.svg",
    weight: 1,
    req_header: "",
    resp_header: "",
    classification: {
      country_code: ["GB", "US", "DE"],
      asn: [5089]
    }
  }
```