### PR TITLE
Expose results to FASTLY global

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -34,6 +34,7 @@ interface Client {
 
 interface Fastly {
   client: Agent;
+  results: Beacon[];
 }
 
 interface Host {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,13 @@ import loadWhenDocumentReady from "./util/loadWhenDocumentReady";
 import getScriptParameters from "./util/scriptQueryParameters";
 import * as worker from "./worker";
 
+// Declare FASTLY global which is used later when assigning the returned state
+declare global {
+  interface Window {
+    FASTLY?: Fastly;
+  }
+}
+
 // List of required features browser features
 const requiredFeatures = ["Worker", "Promise", "fetch"];
 // Test whether browser has required feature support
@@ -13,7 +20,10 @@ const hasFeatureSupport = hasProperties(window, requiredFeatures);
 const state: Fastly = {
   client: {
     hasFeatureSupport
-  }
+  },
+  // The are certain scenarios (such as the demo website) in which the global
+  // FASTLY and the results array already exists.
+  results: (window.FASTLY && window.FASTLY.results) || []
 };
 
 // Init initializes the library when the browser is ready
@@ -21,7 +31,16 @@ export function init(): void {
   loadWhenDocumentReady(
     (): void => {
       const params = getScriptParameters(SCRIPT_SRC_REGEXP);
-      worker.init(params).catch((): void => {});
+      worker
+        .init(params)
+        .then(
+          (results: Beacon[]): void => {
+            // We use apply here as we don't want to directly assign i.e.
+            // replace the existing results array.
+            Array.prototype.push.apply(state.results, results);
+          }
+        )
+        .catch((): void => {});
     }
   );
 }


### PR DESCRIPTION
*⚠️ Note this is a PR into the v.2.0.0 branch and not master*

### TL;DR
Exposes the final results array to the window global `FASTLY`. This follows the same conventions in master/v1 of the library. The results array is mainly exposed for debugging purposes, however we also use this array to implement the https://insights.fastlylabs.com/test page, as it uses a `Proxy` assigned to the global to listen to new results and visualise in the UI.