### PR TITLE
Support template string placeholders in the task.resource URL field

### DIFF
--- a/src/lib/templateResource.spec.ts
+++ b/src/lib/templateResource.spec.ts
@@ -1,0 +1,29 @@
+/* eslint-disable indent */
+import templateResource from "./templateResource";
+import { mockRandomForEach } from "jest-mock-random";
+import configFixture from "../fixtures/config";
+
+describe("templateResource", (): void => {
+  mockRandomForEach(
+    Array(16)
+      .fill(0.01)
+      .map((v, i): number => v * i)
+  );
+  it.each`
+    input                                                                       | expected
+    ${""}                                                                       | ${""}
+    ${"https://www.fastly-insights.com/o.svg"}                                  | ${"https://www.fastly-insights.com/o.svg"}
+    ${"https://www.fastly insights.com/o.svg"}                                  | ${"https://www.fastlyinsights.com/o.svg"}
+    ${"https://www.fastly-insights.com/o.svg?id=<% TEST_ID %>"}                 | ${"https://www.fastly-insights.com/o.svg?id=42c91a26-c33f-482a-9ac9-353cd615c0a9"}
+    ${"https://www.fastly-insights.com/o.svg?id=<%TEST_ID%>"}                   | ${"https://www.fastly-insights.com/o.svg?id=42c91a26-c33f-482a-9ac9-353cd615c0a9"}
+    ${"https://www.fastly-insights.com/o.svg?id=<%test_Id%>"}                   | ${"https://www.fastly-insights.com/o.svg?id=42c91a26-c33f-482a-9ac9-353cd615c0a9"}
+    ${"https://<%TEST_ID%>.fastly-insights.com/o.svg?id=<%TEST_ID%>"}           | ${"https://42c91a26-c33f-482a-9ac9-353cd615c0a9.fastly-insights.com/o.svg?id=42c91a26-c33f-482a-9ac9-353cd615c0a9"}
+    ${"https://www.fastly-insights.com/o.svg?rand=<%RANDOM%>"}                  | ${"https://www.fastly-insights.com/o.svg?rand=AABBCDDEEFGGHIIJ"}
+    ${"https://www.fastly-insights.com/o.svg?id=<% TEST_ID %>&rand=<%RANDOM%>"} | ${"https://www.fastly-insights.com/o.svg?id=42c91a26-c33f-482a-9ac9-353cd615c0a9&rand=AABBCDDEEFGGHIIJ"}
+  `(
+    'Should template the input string "$input" correctly',
+    ({ input, expected }): void => {
+      expect(templateResource(input, configFixture)).toBe(expected);
+    }
+  );
+});

--- a/src/lib/templateResource.ts
+++ b/src/lib/templateResource.ts
@@ -1,0 +1,43 @@
+type ResourceReducer =
+  | ((resource: string, config: Config) => string)
+  | ((resource: string) => string);
+
+const DICTIONARY =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+const DICTIONARY_LENGTH = DICTIONARY.length;
+const RANDOM_LENGTH = 16;
+
+// Removes all spaces from string, this allows the other reducers to have more
+// reliable match patterns as they don't need to be concerned about whitespace.
+function removeWhitespace(resource: string): string {
+  return resource.replace(/\s/g, "");
+}
+
+// Replaces the template placeholder <% RANDOM %> with a random string
+function replaceRandom(resource: string): string {
+  const randomLetter = (): string =>
+    DICTIONARY.charAt(Math.floor(Math.random() * DICTIONARY_LENGTH));
+  const random = Array(RANDOM_LENGTH)
+    .fill(null)
+    .reduce((acc): string => acc + randomLetter(), "");
+  return resource.replace(/<%RANDOM%>/gi, random);
+}
+
+// Replaces the template placeholder <% TEST_ID %> with the test ID from config
+function replaceTestId(resource: string, config: Config): string {
+  return resource.replace(/<%TEST_ID%>/gi, config.test.id);
+}
+
+export default function templateResource(
+  resource: string,
+  config: Config
+): string {
+  // Note: removeWhitespace must come first to ensure the proceeding reducers
+  // are consitent and deterministic.
+  const reducers: ResourceReducer[] = [
+    removeWhitespace,
+    replaceTestId,
+    replaceRandom
+  ];
+  return reducers.reduce((acc, r): string => r(acc, config), resource);
+}

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -1,6 +1,7 @@
 import assign from "../util/assign";
 import { beacon } from "../util/beacon";
 import { getClientInfo } from "../util/client-info";
+import templateResource from "../lib/templateResource";
 
 interface State {
   hasRan: boolean;
@@ -53,6 +54,7 @@ abstract class Task implements TaskInterface {
     this.beacon = assign({}, blankBeacon);
     this.config = assign({}, config);
     this.data = data;
+    this.data.resource = templateResource(this.data.resource, config);
   }
 
   private encode(data: Beacon): string {


### PR DESCRIPTION
**⚠️ Note this is a PR into the v.2.0.0 branch and not master**

### TL;DR
This allows the task resources returned from the API to contain template placeholder substrings, such as `<% TEST_ID %>`, which get replaced with a real value at execution time. This is useful to encode dynamic properties such as the test ID or a random string in the request URL for cache busting or correlation purposes. 

