### PR TITLE
Use the fastly-insights.com apex for the config API request

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -35,11 +35,10 @@ function getConfig(url: string): Promise<Config> {
   return retry(fetchJSON);
 }
 
-export function init({
-  host,
-  k: apiToken
-}: QueryParameters): Promise<Beacon[]> {
-  const configHost = PRODUCTION ? host : "https://test.fastly-insights.com";
+export function init({ k: apiToken }: QueryParameters): Promise<Beacon[]> {
+  const configHost = PRODUCTION
+    ? "https://fastly-insights.com"
+    : "https://test.fastly-insights.com";
   const configUrl = `${configHost}${CONFIG_PATH}${apiToken}`;
   return getConfig(configUrl)
     .then(runTasks)


### PR DESCRIPTION
### TL;DR
Use the `https://fastly-insights.com` apex hostname for the config API request. This allows us to set a  single [Network Error Logging](https://www.w3.org/TR/network-error-logging/) policy that will apply to all subdomain's of the domain.