### PR TITLE
Fix the config API hostname in pre-production environments

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7,9 +7,6 @@ import sequence from "./util/promiseSequence";
 import { create as createTask } from "./tasks";
 import Task from "./tasks/task";
 
-// This is declared via Webpack DefinePlugin at compile time
-declare const PRODUCTION: boolean;
-
 function runTasks(configuration: Config): Promise<Beacon[]> {
   const {
     client,
@@ -35,10 +32,14 @@ function getConfig(url: string): Promise<Config> {
   return retry(fetchJSON);
 }
 
-export function init({ k: apiToken }: QueryParameters): Promise<Beacon[]> {
-  const configHost = PRODUCTION
-    ? "https://fastly-insights.com"
-    : "https://test.fastly-insights.com";
+export function init({
+  host,
+  k: apiToken
+}: QueryParameters): Promise<Beacon[]> {
+  const configHost =
+    host === "https://www.fastly-insights.com"
+      ? "https://fastly-insights.com"
+      : host;
   const configUrl = `${configHost}${CONFIG_PATH}${apiToken}`;
   return getConfig(configUrl)
     .then(runTasks)


### PR DESCRIPTION
### TL;DR
This fixes a bug introduced in #50 in which we were using the apex hostname for all environments. Now we only use the apex if the script host is `www.` and fallback to using the script host in other environments. 