### PR TITLE
Add Sauce Labs Open Sauce testing support badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,5 +161,8 @@ We may retain the raw information collected from individual Fastly Insights sess
 ### Fastly’s commitment to transparency
 Any changes to this FAQ document and the data we collect over time will be logged in our [change log](https://github.com/fastly/insights.js/blob/master/CHANGELOG.md).
 
+## Community Support
+<img alt="Testing Powered By SauceLabs" src="https://raw.githubusercontent.com/saucelabs/opensource/master/assets/powered-by-saucelabs-badge-white.svg?sanitize=true" width="160">
+
 ## License
 [MIT](https://github.com/fastly/insights.js/blob/master/LICENSE)


### PR DESCRIPTION
### TL;DR
The project has kindly been approved for free open source cross-browser testing from SauceLabs, a requirement of which is to have this badge to give credit to Sauce Labs for their support. Which we will very happily do 😄  

### Note
I will be following up with some further PRs to introduce a small E2E test suite using Sauce Labs.