### PR TITLE
Ensure the actual beacon result is returned and not the TestResultBundle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,14 @@ if (hasFeatureSupport) {
     // We use apply here as we don't want to directly assign i.e.
     // replace the existing results array, there are also certain scenarios
     // (such as the demo website) in which the results array already exists as
-    // an Aarry-like object and thus using apply() is required.
-    Array.prototype.push.apply(state.results, result.testResults);
+    // an Array-like object and thus using apply() is required.
+    Array.prototype.push.apply(
+      state.results,
+      result.testResults
+        .filter((r) => r.beaconData !== undefined)
+        /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+        .map((r) => r!.beaconData!.data)
+    );
   });
 }
 


### PR DESCRIPTION
### TL;DR
I missed this in the v3  migration (#62), the return value from the Open Insights `init()` method is a [`TestResultBundle[]`](https://open-insights-docs.edgecompute.app/interfaces/__types_index_.testresultbundle.html) and not beacon object which it previously was. This has subsequently broken the test application at https://insights.fastlylabs.com/test as it assumes a different data structure. Therefore the solution is to map the result to the beacon object. 