### PR TITLE
Bump open-insights-provider-fastly to v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "@fastly/open-insights-provider-fastly": "^1.0.0",
+        "@fastly/open-insights-provider-fastly": "^1.0.1",
         "@openinsights/openinsights": "^0.2.1"
       },
       "devDependencies": {
@@ -1156,9 +1156,9 @@
       }
     },
     "node_modules/@fastly/open-insights-provider-fastly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@fastly/open-insights-provider-fastly/-/open-insights-provider-fastly-1.0.0.tgz",
-      "integrity": "sha512-8FdCOV5C50cPsDK44nhy7eNbTtb6bkMI0MkBwx2kcpGvqDhsINtAqW5/oXRp2pMUPXjpM04l0VEvwvesdOuXeg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@fastly/open-insights-provider-fastly/-/open-insights-provider-fastly-1.0.1.tgz",
+      "integrity": "sha512-2tfvddg5Ybh4LjLWnYwTojGk6tuuxl8xCEl2l+H3jEbHQmRCvjgA+fk2TU6XZGx63X+rRoqEGn0ccNH8ckmZ/A==",
       "dependencies": {
         "@fastly/performance-observer-polyfill": "^2.0.0",
         "@openinsights/openinsights": "^0.2.1",
@@ -11328,9 +11328,9 @@
       }
     },
     "@fastly/open-insights-provider-fastly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@fastly/open-insights-provider-fastly/-/open-insights-provider-fastly-1.0.0.tgz",
-      "integrity": "sha512-8FdCOV5C50cPsDK44nhy7eNbTtb6bkMI0MkBwx2kcpGvqDhsINtAqW5/oXRp2pMUPXjpM04l0VEvwvesdOuXeg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@fastly/open-insights-provider-fastly/-/open-insights-provider-fastly-1.0.1.tgz",
+      "integrity": "sha512-2tfvddg5Ybh4LjLWnYwTojGk6tuuxl8xCEl2l+H3jEbHQmRCvjgA+fk2TU6XZGx63X+rRoqEGn0ccNH8ckmZ/A==",
       "requires": {
         "@fastly/performance-observer-polyfill": "^2.0.0",
         "@openinsights/openinsights": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@fastly/open-insights-provider-fastly": "^1.0.0",
+    "@fastly/open-insights-provider-fastly": "^1.0.1",
     "@openinsights/openinsights": "^0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### TL;DR
Bumps [open-insights-provider-fastly](https://github.com/fastly/open-insights-provider-fastly) to 1.0.1 which ensures the resource timing server-timing property is included in the beacon payload. 